### PR TITLE
Fix parameters with spaces (inside " ") not working in Windows.

### DIFF
--- a/minion.bat
+++ b/minion.bat
@@ -17,7 +17,7 @@ rem minion task:name --help
 
 set TASK=""
 
-if not "%*"=="" set TASK=--task=%*
+if not "%1"=="" set TASK=--task=%*
 
 set KOHANA_PATH=%~dp0
 


### PR DESCRIPTION
--option="This has spaces" wasn't working; this fixes it for me.
